### PR TITLE
added tailwindcss to deps, including yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@astrojs/rss": "^3.0.0",
         "@tailwindcss/typography": "^0.5.10",
-        "preact": "^10.15.1"
+        "preact": "^10.15.1",
+        "tailwindcss": "^3.3.3"
     }
 }


### PR DESCRIPTION
Project was missing tailwindcss dependency so it wouldn't start. I also included yarn.lock as there was no lockfile present at all. Let me know if that was intentional and I can remove that and resubmit the PR.